### PR TITLE
Ability to run custom behavior scripts!

### DIFF
--- a/scripts/custom/README.md
+++ b/scripts/custom/README.md
@@ -1,0 +1,9 @@
+# Custom scripts for client containers
+
+Welcome! You have the ability to add arbitrary custom Python scripts to this folder so that they can be run as the behavior of client containers.
+
+Common scripts utilize Selenium and perform different internet browsing related activities, such as watching videos, surfing the web, downloading files, etc.
+
+For your sanity, you should test that the script can be run within a client container successfully. Remember that a browser running in these containers *will be headless*! Add any necessary pip libraries to a `requirements.txt` file within this folder.
+
+Remember to set the behavior string to `"custom/<filename.py>"` in the config file.

--- a/scripts/custom/requirements.txt
+++ b/scripts/custom/requirements.txt
@@ -1,0 +1,1 @@
+# Add any additional pip requirements for custom scripts here!

--- a/scripts/daemon.py
+++ b/scripts/daemon.py
@@ -182,6 +182,16 @@ def setup_client(client):
         behavior_command = 'python -m scripts.selenium-browsing-automation.scripts.streaming.youtube_selenium.py'
     elif behavior == 'browsing':
         behavior_command = 'python scripts.selenium-browsing-automation.scripts.browsing.endless-scroll.py' 
+
+    # We allow custom scripts to be run when behavior is `custom/<filename.py>`,
+    # in which case we tell the client to pip install any requirements and run
+    # that file.
+    elif behavior.startswith('custom/'):
+        path_to_script = f'scripts/{behavior}'
+        path_to_requirements = 'scripts/custom/requirements.txt'
+        
+        behavior_command = f'pip install -r {path_to_requirements}; python {path_to_script}'
+
     elif behavior is None:
         logging.warning(f'Target behavior for `{client.name}` not found; will sleep.')
         pass

--- a/setup/build_compose.py
+++ b/setup/build_compose.py
@@ -78,8 +78,11 @@ def main(tool_dir, config_file, env_file, data_dir):
         for behavior in behaviors: # -- Clients
 
             client = copy.deepcopy(components['client'])
-            # This doesn't handle duplicates/replicas.
-            client_name = f'client-{network_name}-{behavior}'
+            
+            # If the behavior is to use a custom script, we strip out 'custom/'
+            # from the behavior to make the compose service name compatible.
+            behavior_name = behavior if not behavior.startswith('custom/') else behavior[len('custom/'):]
+            client_name = f'client-{network_name}-{behavior_name}'
             client['depends_on'].append(router_name)
             client['networks'].append(network_name)
             client['labels']['com.netem.behavior'] = behavior
@@ -95,6 +98,8 @@ def main(tool_dir, config_file, env_file, data_dir):
             # Specify shared memory
             client['shm_size'] = config['client']['shared_memory_size']
 
+            # NOTE: This doesn't handle duplicates/replicas. The service name
+            # will be the same and thus will share the same key in the dict.
             compose['services'][client_name] = client
 
     built_file = Path(tool_dir, 'built/docker-compose.yml')


### PR DESCRIPTION
To have the client run a custom behavior script, add a Python file to `scripts/custom/filename.py`, add any pip requirements to `scripts/custom/requirements.txt`, and configure the behavior to be `"custom/filename.py"`.

Example:
```python
# scripts/custom/euler.py

import numpy as np
print(np.real(np.exp(1j * np.pi)))
```
```python
# scripts/custom/requirements.txt

numpy
```
```json
# config.json

{
  "behaviors": [
    "custom/euler.py",
    "..."
  ],
  "..."
}
```